### PR TITLE
Add git-global-config input

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ The following inputs can be used to control the action's behavior:
 * `ssh-agent-cmd`: Optional. Use this to specify a custom location for the `ssh-agent` binary.
 * `ssh-add-cmd`: Optional. Use this to specify a custom location for the `ssh-add` binary.
 * `git-cmd`: Optional. Use this to specify a custom location for the `git` binary.
+* `git-global-config`: Optional. Alter the global git config? If `false` only the git config in the current working directory will be altered. Defaults to `false`.
+  > [!IMPORTANT]
+  >
+  > Using this option also sets the `GIT_CONFIG_NOSYSTEM` environment variable.
+  > This prevents the global git config from being read from the system-wide configuration file.
 
 ## Exported variables
 

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     git-cmd:
         description: 'git command'
         required: false
+    git-global-config:
+        description: 'Alter the global git configuration?'
+        default: false
 runs:
     using: 'node20'
     main: 'dist/index.js'

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,6 +1,11 @@
 const { execSync, execFileSync } = require("node:child_process");
 const { keyFilePrefix } = require("./consts.js");
-const { gitCmd, homePath, sshAgentCmd } = require("./paths.js");
+const {
+  gitCmd,
+  gitGlobalConfig,
+  homePath,
+  sshAgentCmd,
+} = require("./paths.js");
 const { alterGitConfigWithRetry } = require("./utils.js");
 const fs = require("node:fs");
 const os = require("node:os");
@@ -20,7 +25,7 @@ function restoreGitConfig(maxTries = 3) {
     console.log("Restoring git config");
     const result = alterGitConfigWithRetry(() => {
       return execSync(
-        `${gitCmd} config --global --get-regexp ".git@${keyFilePrefix}."`,
+        `${gitCmd} config${gitGlobalConfig} --get-regexp ".git@${keyFilePrefix}."`,
       );
     });
     const sections = result
@@ -34,7 +39,7 @@ function restoreGitConfig(maxTries = 3) {
         console.log(`Removing git config section ${section}`);
         alterGitConfigWithRetry(() => {
           return execSync(
-            `${gitCmd} config --global --remove-section ${section}`,
+            `${gitCmd} config${gitGlobalConfig} --remove-section ${section}`,
           );
         });
       }

--- a/dist/cleanup.js
+++ b/dist/cleanup.js
@@ -3432,6 +3432,7 @@ const defaults =
 const sshAgentCmdInput = core.getInput("ssh-agent-cmd");
 const sshAddCmdInput = core.getInput("ssh-add-cmd");
 const gitCmdInput = core.getInput("git-cmd");
+const gitGlobalConfigInput = core.getBooleanInput("git-global-config");
 
 module.exports = {
   homePath: defaults.homePath,
@@ -3439,6 +3440,7 @@ module.exports = {
     sshAgentCmdInput !== "" ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
   sshAddCmd: sshAddCmdInput !== "" ? sshAddCmdInput : defaults.sshAddCmdDefault,
   gitCmd: gitCmdInput !== "" ? gitCmdInput : defaults.gitCmdDefault,
+  gitGlobalConfig: gitGlobalConfigInput ? " --global" : "",
 };
 
 
@@ -3660,7 +3662,12 @@ module.exports = require("util");
 var __webpack_exports__ = {};
 const { execSync, execFileSync } = __nccwpck_require__(421);
 const { keyFilePrefix } = __nccwpck_require__(334);
-const { gitCmd, homePath, sshAgentCmd } = __nccwpck_require__(644);
+const {
+  gitCmd,
+  gitGlobalConfig,
+  homePath,
+  sshAgentCmd,
+} = __nccwpck_require__(644);
 const { alterGitConfigWithRetry } = __nccwpck_require__(561);
 const fs = __nccwpck_require__(24);
 const os = __nccwpck_require__(161);
@@ -3680,7 +3687,7 @@ function restoreGitConfig(maxTries = 3) {
     console.log("Restoring git config");
     const result = alterGitConfigWithRetry(() => {
       return execSync(
-        `${gitCmd} config --global --get-regexp ".git@${keyFilePrefix}."`,
+        `${gitCmd} config${gitGlobalConfig} --get-regexp ".git@${keyFilePrefix}."`,
       );
     });
     const sections = result
@@ -3694,7 +3701,7 @@ function restoreGitConfig(maxTries = 3) {
         console.log(`Removing git config section ${section}`);
         alterGitConfigWithRetry(() => {
           return execSync(
-            `${gitCmd} config --global --remove-section ${section}`,
+            `${gitCmd} config${gitGlobalConfig} --remove-section ${section}`,
           );
         });
       }

--- a/paths.js
+++ b/paths.js
@@ -23,6 +23,7 @@ const defaults =
 const sshAgentCmdInput = core.getInput("ssh-agent-cmd");
 const sshAddCmdInput = core.getInput("ssh-add-cmd");
 const gitCmdInput = core.getInput("git-cmd");
+const gitGlobalConfigInput = core.getBooleanInput("git-global-config");
 
 module.exports = {
   homePath: defaults.homePath,
@@ -30,4 +31,5 @@ module.exports = {
     sshAgentCmdInput !== "" ? sshAgentCmdInput : defaults.sshAgentCmdDefault,
   sshAddCmd: sshAddCmdInput !== "" ? sshAddCmdInput : defaults.sshAddCmdDefault,
   gitCmd: gitCmdInput !== "" ? gitCmdInput : defaults.gitCmdDefault,
+  gitGlobalConfig: gitGlobalConfigInput ? " --global" : "",
 };


### PR DESCRIPTION
Allows to only alter the local git config.
This prevents multiple runners in parallel
interfering with each other.